### PR TITLE
retours(dsfr_focus_widget): améliorer la gestion du focus

### DIFF
--- a/lib/src/atoms/dsfr_focus_widget.dart
+++ b/lib/src/atoms/dsfr_focus_widget.dart
@@ -15,22 +15,38 @@ class DsfrFocusWidget extends StatelessWidget {
   final Widget child;
 
   @override
-  Widget build(final BuildContext context) => DecoratedBox(
-        decoration: BoxDecoration(
-          border: isFocused
-              ? Border.fromBorderSide(
-                  BorderSide(
-                    color: DsfrColorDecisionsExtension.focus525(context),
-                    width: DsfrSpacings.s0v5,
-                    strokeAlign: BorderSide.strokeAlignOutside,
+  Widget build(final BuildContext context) {
+    const marginAroundChild = DsfrSpacings.s0v5;
+
+    return Stack(
+      fit: StackFit.passthrough,
+      clipBehavior: Clip.none,
+      children: [
+        child,
+        if (isFocused)
+          Positioned(
+            left: -marginAroundChild,
+            top: -marginAroundChild,
+            right: -marginAroundChild,
+            bottom: -marginAroundChild,
+            child: IgnorePointer(
+              child: DecoratedBox(
+                decoration: BoxDecoration(
+                  border: Border.fromBorderSide(
+                    BorderSide(
+                      color: DsfrColorDecisionsExtension.focus525(context),
+                      width: marginAroundChild,
+                      strokeAlign: BorderSide.strokeAlignOutside,
+                    ),
                   ),
-                )
-              : null,
-          borderRadius: borderRadius?.add(const BorderRadius.all(Radius.circular(DsfrSpacings.s0v5))),
-        ),
-        child: Padding(
-          padding: const EdgeInsets.all(DsfrSpacings.s0v5),
-          child: child,
-        ),
-      );
+                  borderRadius: borderRadius?.add(
+                    const BorderRadius.all(Radius.circular(marginAroundChild)),
+                  ),
+                ),
+              ),
+            ),
+          ),
+      ],
+    );
+  }
 }


### PR DESCRIPTION
Il permet à l'encadrer bleu d'être à l'extérieur de l'enfant, ainsi la taille de l'enfant n'est pas influencé.

On voit sur les photos ci-dessous que les `spacings` entre les éléments fait bien la taille attendue.
Avant ça faisait `spacings + 2 + 2`

| Actuel | PR Unfocus | PR Focus |
| - | - | - |
| <img width="373" alt="image" src="https://github.com/user-attachments/assets/1e06ba5d-591d-4d78-a9d4-4c01e099d348" /> | <img width="373" alt="image" src="https://github.com/user-attachments/assets/883e3566-322d-41c6-9902-062a3f6d64f6" /> | <img width="373" alt="image" src="https://github.com/user-attachments/assets/773454c4-75eb-432c-b6f9-fa5efb375072" /> |

Solution largement inspirée par https://github.com/bdlukaa/fluent_ui/blob/master/lib/src/controls/utils/focus.dart